### PR TITLE
Fixing TypeError: Cannot set properties of undefined (setting 'default')

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,7 @@
 "use strict";
 
-var path = require("path");
-
-module.exports.rules["default"] =
-	require(
-		path.join(__dirname,"rules","no-optional-call.js")
-	);
+module.exports = {
+	rules: {
+		default: require("./rules/no-optional-call"),
+	},
+};


### PR DESCRIPTION
When using this plugin I ran into this issue: "TypeError: Failed to load plugin 'no-optional-call' declared in '.eslintrc.js': Cannot set properties of undefined (setting 'default')".

Using:

eslint: 8.37.0 with this, partial, config:

```js
module.exports = {
  env: {
    es2022: true,
    node: true,
  },
  parserOptions: {
    ecmaVersion: 'latest',
    sourceType: 'module',
    ecmaFeatures: {
      impliedStrict: false,
    },
  },
  plugins: [
    'no-optional-call',
  ],
  rules: {
    'no-optional-call/default': 'error',
  }
}
```

